### PR TITLE
Update for P2IU constructors and tests

### DIFF
--- a/installer/src/panels/com/jboss/devstudio/core/installer/bean/P2IU.java
+++ b/installer/src/panels/com/jboss/devstudio/core/installer/bean/P2IU.java
@@ -24,6 +24,10 @@ public class P2IU {
 		this.path = path;
 		this.size = size;
 	}
+	public P2IU(String id, String label, String description, String path) {
+		this(Boolean.FALSE,id,label,description, path, "0");
+	}
+	
 	public P2IU(String id, String label, String description, String path, String size) {
 		this(Boolean.FALSE,id,label,description, path, size);
 	}

--- a/installer/src/test/com/jboss/devstudio/core/installer/bean/P2IUListBeanTest.java
+++ b/installer/src/test/com/jboss/devstudio/core/installer/bean/P2IUListBeanTest.java
@@ -11,13 +11,13 @@ public class P2IUListBeanTest extends TestCase {
 	public P2IUListBean createTestBean() {
 		P2IUListBean pl = new P2IUListBean(
 				Arrays.asList(new P2IU[]{
-					new P2IU(true,"id1","label1","Description 1", "devstudio1", ""),
+					new P2IU(true,"id1","label1","Description 1", "devstudio1", "0"),
 					new P2IU(true,"id2","label2","Description 2", "devstudio2", "10"),
 					new P2IU(true,"id3","label3","Description 3", "devstudio1", "100"),
 					new P2IU(true,"id4","label4","Description 4", "devstudio2", "1000")
 				}),
 				Arrays.asList(new P2IU[]{
-					new P2IU(true,"id5","label5","Description 5", "devstudio1", ""),
+					new P2IU(true,"id5","label5","Description 5", "devstudio1", "0"),
 					new P2IU(true,"id6","label6","Description 6", "devstudio2", "10"),
 					new P2IU(true,"id7","label7","Description 7", "devstudio1", "100"),
 					new P2IU(true,"id8","label8","Description 8", "devstudio2", "1000")
@@ -36,9 +36,9 @@ public class P2IUListBeanTest extends TestCase {
 		assertEquals("devstudio1,devstudio2", pl.getCommaSeparatedLocationStringList());
 	}
 
-         public void testGetCommaSeparatedSizeStringList() {
+   public void testGetCommaSeparatedSizeStringList() {
 		P2IUListBean pl = createTestBean();
-		assertEquals("devstudio1,devstudio2", pl.getCommaSeparatedSizeStringList());
+		assertEquals("0,10,100,1000", pl.getCommaSeparatedSizeStringList());
 	}
 
 }


### PR DESCRIPTION
This fix:
- keeps old constructor without size, so tests using it do not need any changes
- adds new constructor with size
- fix test for new method getting list of comma separated sizes
